### PR TITLE
Fix broken internal links in /framework and unlink offline data.disclose.io

### DIFF
--- a/content/docs/project-directory.md
+++ b/content/docs/project-directory.md
@@ -70,7 +70,7 @@ The definitive community-powered database of every known vulnerability disclosur
 
 Internet-wide survey data on vulnerability disclosure program adoption, generated from diosts scans and community contributions. Used by researchers, policymakers, and organizations for tracking industry progress.
 
-[data.disclose.io](https://data.disclose.io) *(currently offline)*
+data.disclose.io *(currently offline)*
 
 ### research-threats — Legal Threats Archive
 

--- a/scripts/preprocess-framework.js
+++ b/scripts/preprocess-framework.js
@@ -66,6 +66,29 @@ function replaceVariables(content) {
   return out;
 }
 
+// Rewrites README-style `.md` links (which work on GitHub) into Hugo slug URLs
+// so they don't 404 in production. Hugo's Goldmark emits `href` literally, so
+// `[text](./file.md)` must become `[text](./file/)` to match the rendered URL.
+function rewriteLinks(content) {
+  // Fix stale "terms/core/vdp.md" reference from the dioterms source — the
+  // real Hugo slug after preprocess is terms/core-vdp/, and the text path is
+  // from an older layout.
+  let out = content.replace(
+    /\[terms\/core\/vdp\.md\]\(\.\.\/terms\/\)/g,
+    '[terms/core-vdp.md](../terms/core-vdp/)'
+  );
+
+  // Strip .md extension from relative markdown link hrefs: `(./x.md)` → `(./x/)`,
+  // `(../d/x.md#anchor)` → `(../d/x/#anchor)`. External (http/https/mailto) and
+  // root-absolute (/...) hrefs are left alone because they match neither prefix.
+  out = out.replace(
+    /(\]\()(\.{1,2}\/[^)\s]+?)\.md(#[^)\s]*)?(\))/g,
+    (_, open, path, anchor = '', close) => `${open}${path}/${anchor}${close}`
+  );
+
+  return out;
+}
+
 function stripFirstH1(content) {
   const lines = content.split('\n');
   const idx = lines.findIndex((line) => line.trim().startsWith('# '));
@@ -112,6 +135,7 @@ function processFile({ src, out, title, description, weight, replaceVariables: d
   let content = fs.readFileSync(srcPath, 'utf8');
   if (doStrip) content = stripFirstH1(content);
   if (doReplace) content = replaceVariables(content);
+  content = rewriteLinks(content);
   const body = frontMatter({ title, description, weight, extra }) + content.trimStart();
   const outPath = path.join(OUT, out);
   const status = writeIfChanged(outPath, body);


### PR DESCRIPTION
## Summary

- Preprocess script (`scripts/preprocess-framework.js`) now rewrites README-style `.md` hrefs from the upstream `dioterms` source into Hugo slug URLs during generation. Fixes five previously 404-ing internal links:
  - `maturity/level-4` → `../practices/coordinated-disclosure/`
  - `maturity/level-5` → `./level-4/`
  - `maturity/level-{1,2,3}` stale `terms/core/vdp.md` reference → `../terms/core-vdp/`
- Unlinks the offline `data.disclose.io` reference in `content/docs/project-directory.md` (keeps the "currently offline" note).

Root cause: Hugo's Goldmark emits `[text](file.md)` hrefs literally, so GitHub-README-style links from the `external/dioterms` submodule become 404s at `/framework/.../file.md` instead of the rendered slug URL `/framework/.../file/`. Fixing in the preprocess script (not the generated content) means future rebuilds stay correct.

## Test plan

- [x] `npm run prebuild` idempotent (2nd run shows all `[unchanged]`)
- [x] `hugo --minify` builds clean; `public/framework/{practices/coordinated-disclosure,terms/core-vdp,maturity/level-{0..5}}/index.html` all present
- [x] Full-site link crawl via linkinator against running `hugo server` → 130/130 pass (0 broken) after both fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)