### PR TITLE
Remove Fathom Analytics

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -145,11 +145,6 @@
   {{ end }}
   {{ end }}
 
-  {{/* Fathom Analytics */}}
-  {{ if eq hugo.Environment "production" }}
-  <script src="https://cdn.usefathom.com/script.js" data-site="OYTNWTTU" defer></script>
-  {{ end }}
-
   {{ block "scripts" . }}{{ end }}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Removes Fathom loader block (`data-site=OYTNWTTU`) from `layouts/_default/baseof.html`
- Removes the surrounding `{{ if eq hugo.Environment "production" }}` conditional (no longer needed)
- GA4 (`G-NJQTCTSYCM`) remains as the sole analytics provider

## Why
Completing the Fathom → GA4 consolidation across the disclose.io estate. Found during a post-deploy audit — disclose.io was still shipping Fathom while all other sites had been cleaned.

## Test plan
- [ ] After merge + deploy, `curl -s https://disclose.io/ | grep usefathom` returns nothing
- [ ] `curl -s https://disclose.io/ | grep G-NJQTCTSYCM` still returns the GA4 loader
- [ ] GA4 Realtime continues to show sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)