### PR TITLE
Add /universe landing page

### DIFF
--- a/content/universe.md
+++ b/content/universe.md
@@ -1,0 +1,40 @@
+---
+title: "The disclose.io Universe"
+description: "The open standard for safe harbor vulnerability disclosure — and the ecosystem that makes it real."
+---
+
+The disclose.io project is the open-source layer between raw standards (ISO 29147, CISA CVD) and commercial platforms — a vendor-agnostic, practitioner-first playbook for coordinated vulnerability disclosure.
+
+Below is the full ecosystem. Every component answers a real question someone asks when they hit the VDP wall.
+
+## Core
+
+- [disclose.io](/) — the framework, docs, and project home
+- [disclose.io/programs](/programs) — curated programs with safe harbor language
+- [disclose.io/platforms](/platforms) — bug bounty platforms supporting safe harbor
+- [disclose.io/threats](/threats) — research on legal threats to security researchers
+- [disclose.io/history](/history) — 20+ years of coordinated disclosure
+
+## Tools
+
+- [lookup.disclose.io](https://lookup.disclose.io?utm_source=universe&utm_medium=onepager&utm_campaign=lookup) — vendor → security contact, program, and safe harbor status
+- [dnssecuritytxt.org](https://dnssecuritytxt.org?utm_source=universe&utm_medium=onepager&utm_campaign=dnssecuritytxt) — DNS-based security contact discovery
+
+## Community
+
+- [community.disclose.io](https://community.disclose.io?utm_source=universe&utm_medium=onepager&utm_campaign=community) — the forum
+- [blog.disclose.io](https://blog.disclose.io?utm_source=universe&utm_medium=onepager&utm_campaign=blog) — updates, commentary, and research
+
+## Open source
+
+- [dioterms](https://github.com/disclose/dioterms?utm_source=universe&utm_medium=onepager&utm_campaign=dioterms) — safe harbor policy templates
+- [diodb](https://github.com/disclose/diodb?utm_source=universe&utm_medium=onepager&utm_campaign=diodb) — open database of disclosure programs
+- [policymaker.disclose.io](https://policymaker.disclose.io?utm_source=universe&utm_medium=onepager&utm_campaign=policymaker) — guided VDP policy generator
+
+## Legal backstop
+
+- [SRLDF](https://srldf.org?utm_source=universe&utm_medium=onepager&utm_campaign=srldf) — Security Research Legal Defense Fund
+
+---
+
+*Contribute, ask questions, or start a program: [hello@disclose.io](mailto:hello@disclose.io).*


### PR DESCRIPTION
## Summary

Adds a single-page ecosystem map at `disclose.io/universe` — the "universe one-pager" captured as a shareable URL on the main property.

- Framework in `content/universe.md` using the default `single.html` layout (same pattern as `thanks.md`, `contact.md`)
- Rides existing GA4 property `G-NJQTCTSYCM` via the site-wide loader — no new tracking setup
- Internal links (programs, platforms, threats, history) use relative URLs — no UTMs (avoids GA session reset on same-property navigation)
- Outbound links (lookup, dnssecuritytxt, community, blog, dioterms, diodb, policymaker, SRLDF) carry `?utm_source=universe&utm_medium=onepager&utm_campaign=<project>` for attribution
- Not added to the top nav per product decision — designed as a precision-use URL for external outreach (Reddit DMs, LinkedIn, peer amplification)

## Test plan

- [x] Hugo serves the page at `http://localhost:1313/universe/` with HTTP 200
- [x] Title "The disclose.io Universe" renders
- [x] All 8 outbound UTM campaigns present in rendered HTML
- [ ] After merge, verify live page at `https://disclose.io/universe` with UTMs intact
- [ ] After merge, confirm GA4 pageview lands on `G-NJQTCTSYCM` under hostname `disclose.io`, path `/universe/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)