### PR TITLE
Revert "Add State of Disclosure + Chrome extension to universe + Tools nav"

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -36,18 +36,6 @@
   weight = 20
 
 [[main]]
-  name = "State of Disclosure"
-  url = "https://state.disclose.io"
-  parent = "Tools"
-  weight = 25
-
-[[main]]
-  name = "Chrome Extension"
-  url = "https://github.com/disclose/chrome-extension-v2"
-  parent = "Tools"
-  weight = 28
-
-[[main]]
   name = "Threats"
   url = "/threats/"
   parent = "Tools"

--- a/content/universe.md
+++ b/content/universe.md
@@ -23,8 +23,6 @@ Below is the full ecosystem. Every component answers a real question someone ask
 ## Tools
 
 - [lookup.disclose.io](https://lookup.disclose.io?utm_source=universe&utm_medium=onepager&utm_campaign=lookup) — vendor → security contact, program, and safe harbor status
-- [state.disclose.io](https://state.disclose.io?utm_source=universe&utm_medium=onepager&utm_campaign=stateofdisclosure) — living one-page snapshot of the ecosystem mapped against the disclose.io maturity model
-- [Chrome extension](https://github.com/disclose/chrome-extension-v2?utm_source=universe&utm_medium=onepager&utm_campaign=chromeext) — toolbar icon shows the VDP posture of the site you're on
 - [dnssecuritytxt.org](https://dnssecuritytxt.org?utm_source=universe&utm_medium=onepager&utm_campaign=dnssecuritytxt) — DNS-based security contact discovery
 
 ## Community


### PR DESCRIPTION
Reverts 2fc5af9. Those two Tools-nav entries weren't meant to ship — state.disclose.io has no CF Pages project or DNS behind it (broken link from prod nav), and the Chrome Extension repo isn't ready for surfacing from main nav.

Touches only `config/_default/menus.toml` and `content/universe.md`. The three commits stacked on top of 2fc5af9 (`4ca6a7b` NextJenSecurity good-faith-research, `911db03` Hackers on the Hill partner, `b4c10e1` partner card spacing) are intact.

Local `hugo --quiet` build succeeds post-revert.