### PR TITLE
Add Lookup to Tools dropdown, under Directory

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -30,6 +30,12 @@
     use_directory_url = true
 
 [[main]]
+  name = "Lookup"
+  url = "https://lookup.disclose.io"
+  parent = "Tools"
+  weight = 15
+
+[[main]]
   name = "Platforms"
   url = "/platforms/"
   parent = "Tools"


### PR DESCRIPTION
Adds `lookup.disclose.io` as the second entry in the main-nav Tools dropdown (weight 15, between Directory weight 10 and Platforms weight 20).

Single-word label matches sibling pattern (Directory / Platforms / Threats / Community). Footer 'Lookup Tool' entry untouched. Mobile nav auto-picks up the same `[[main]]` block.

Local Hugo build clean. No other surfaces changed.