### PR TITLE
Align /platforms with directory.disclose.io as canonical home

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -43,7 +43,6 @@ pygmentsUseClasses = true
     mediaType = "text/plain"
     baseName = "llms-full"
     isPlainText = true
-    notAlternative = true
 
 # Minification
 [minify]

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -29,7 +29,7 @@ pygmentsUseClasses = true
 
 # Output formats
 [outputs]
-  home = ["HTML", "RSS", "JSON"]
+  home = ["HTML", "RSS", "JSON", "LLMSFULL"]
   section = ["HTML", "RSS"]
   page = ["HTML"]
 
@@ -39,6 +39,11 @@ pygmentsUseClasses = true
     mediaType = "application/json"
     baseName = "index"
     isPlainText = true
+  [outputFormats.LLMSFULL]
+    mediaType = "text/plain"
+    baseName = "llms-full"
+    isPlainText = true
+    notAlternative = true
 
 # Minification
 [minify]

--- a/content/framework/_index.md
+++ b/content/framework/_index.md
@@ -3,6 +3,7 @@ title: "The disclose.io Framework"
 description: "The disclose.io Framework: canonical legal terms for vulnerability disclosure, plus the diostatus program-maturity model."
 type: framework
 weight: 1
+tldr: "The disclose.io Framework is the open-source, public-domain reference for running a vulnerability disclosure program (VDP). It provides canonical legal terms organizations can drop into their own policies, a shared vocabulary security researchers use when reading or critiquing programs, and the diostatus six-level maturity model for measuring program quality over time. All Framework content is licensed CC0 1.0 and is editable at github.com/disclose/dioterms."
 ---
 
 The disclose.io Framework is our open-source, public-domain reference for running a vulnerability disclosure program — starting-point boilerplate for organisations, shared vocabulary for security researchers reading or critiquing programs, and a way to measure maturity over time. It's all open for review and contribution, so if you spot something off, you can [open a PR at github.com/disclose/dioterms](https://github.com/disclose/dioterms) (licensed [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/)).

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -2,4 +2,5 @@
 title: "Bug Bounty Platforms"
 description: "A community-powered collection of all known bug bounty platforms, vulnerability disclosure platforms, and crowdsourced security platforms."
 layout: "platforms"
+tldr: "disclose.io maintains a community-curated directory of every known bug bounty, vulnerability disclosure, and crowdsourced security platform. Each entry includes the platform's name, primary URL, geographic focus, and disclosure model. The list is open-source and updated continuously at github.com/disclose/bug-bounty-platforms."
 ---

--- a/content/platforms.md
+++ b/content/platforms.md
@@ -2,5 +2,5 @@
 title: "Bug Bounty Platforms"
 description: "A community-powered collection of all known bug bounty platforms, vulnerability disclosure platforms, and crowdsourced security platforms."
 layout: "platforms"
-tldr: "disclose.io maintains a community-curated directory of every known bug bounty, vulnerability disclosure, and crowdsourced security platform. Each entry includes the platform's name, primary URL, geographic focus, and disclosure model. The list is open-source and updated continuously at github.com/disclose/bug-bounty-platforms."
+tldr: "disclose.io maintains a community-curated list of every known bug bounty, vulnerability disclosure, and crowdsourced security platform. Each entry includes the platform's name, primary URL, geographic focus, and disclosure model. The canonical disclose.io database — including both platforms and individual programs — lives at directory.disclose.io."
 ---

--- a/content/programs.md
+++ b/content/programs.md
@@ -2,4 +2,5 @@
 title: "VDP Programs"
 description: "Search vulnerability disclosure and bug bounty programs in our database."
 layout: "programs"
+tldr: "disclose.io maintains the largest open directory of vulnerability disclosure programs (VDPs) and bug bounty programs on the public internet. Each entry includes the organization, in-scope assets, disclosure policy URL, and any safe-harbor language. The directory is searchable, free to use, and powers downstream tools including lookup.disclose.io."
 ---

--- a/content/threats.md
+++ b/content/threats.md
@@ -2,4 +2,5 @@
 title: "Research Threats"
 description: "An ongoing archive of legal threats made against security researchers engaged in good-faith vulnerability disclosure."
 layout: "threats"
+tldr: "disclose.io maintains the canonical public archive of legal threats made against security researchers engaged in good-faith vulnerability disclosure. Each entry records the date, the organization that made the threat, the researcher(s) targeted, the topic, and the eventual outcome. The archive is open-source at github.com/disclose/research-threats and is updated as incidents are reported and verified."
 ---

--- a/content/tools.md
+++ b/content/tools.md
@@ -1,0 +1,36 @@
+---
+title: "Tools"
+description: "Free, open-source tools from the disclose.io project — for organizations launching a VDP, for researchers finding the right contact, and for everyone working to make vulnerability disclosure simpler."
+tldr: "disclose.io maintains four free, open-source tools that cover the full disclosure lifecycle: Policymaker generates VDP policy text from canonical templates, Directory and Lookup help anyone find the right disclosure contact for any asset, and Vault cryptographically enforces disclosure deadlines so a committed timeline cannot be reversed."
+---
+
+The disclose.io project ships four tools — each free, each open-source, each addressing a specific friction in the vulnerability disclosure pipeline.
+
+## Policymaker
+**[policymaker.disclose.io](https://policymaker.disclose.io)** — Interactive policy generator
+
+Generates a customized vulnerability disclosure policy (VDP) for any organization using the canonical legal terms from the [disclose.io Framework](/framework/). Pick a maturity level, fill in the organization name and contact channel, and walk away with safe-harbor language, a security.txt file, and a complete disclose.io-compliant policy.
+
+## Directory
+**[directory.disclose.io](https://directory.disclose.io)** — The open VDP and bug bounty programs database
+
+Browse every known vulnerability disclosure and bug bounty program. Each entry includes the organization, in-scope assets, policy URL, and any safe-harbor language. Open-source, community-curated, and the data source behind the [Lookup](#lookup) attribution tool.
+
+## Lookup
+**[lookup.disclose.io](https://lookup.disclose.io)** — Security contact attribution
+
+Turn any input — domain, IP, URL, email, ASN, npm package, mobile app, hardware product, free-text company name — into the right disclosure contact. The tool chains 11 attribution strategies (security.txt, the Directory, WHOIS, DNS SOA, common security@ aliases, bug bounty platform records, and more) and returns the highest-confidence contact with provenance. Available as a web UI, HTTP API, and MCP server.
+
+## Vault
+**[vault.disclose.io](https://vault.disclose.io)** — Cryptographically enforced disclosure deadlines
+
+A dead-man's-switch for vulnerability disclosure. A researcher commits a disclosure with a future publication date; the disclosure is encrypted with a timelock that cannot be bypassed, even by the operators of the vault. On expiry, the disclosure becomes publicly readable — regardless of what happens to anyone involved.
+
+## Browser extension
+**[Chrome extension](https://chromewebstore.google.com/detail/discloseio/efelnoglhabpipbgneeoehjbcmiclpda)** *(also referenced as the Disclose extension)*
+
+Surfaces the disclose.io directory's VDP posture for any site you visit — see at a glance whether the organization has a published VDP, what their safe-harbor language is, and where to report a vulnerability.
+
+## Browse the source
+
+Every tool is open-source under the [github.com/disclose](https://github.com/disclose) organization. Contributions, issue reports, and policy improvements all welcome.

--- a/content/universe.md
+++ b/content/universe.md
@@ -15,6 +15,7 @@ Below is the full ecosystem. Every component answers a real question someone ask
 ## Core
 
 - [disclose.io](/) — the framework, docs, and project home
+- [directory.disclose.io](https://directory.disclose.io?utm_source=universe&utm_medium=onepager&utm_campaign=directory) — the canonical disclose.io database of programs and platforms
 - [disclose.io/programs](/programs) — curated programs with safe harbor language
 - [disclose.io/platforms](/platforms) — bug bounty platforms supporting safe harbor
 - [disclose.io/threats](/threats) — research on legal threats to security researchers

--- a/data/navigation/boxes.yaml
+++ b/data/navigation/boxes.yaml
@@ -10,6 +10,11 @@
   icon: "search"
   url: "https://directory.disclose.io"
 
+- title: "I'm researching a program"
+  description: "Browse the open directory of every known vulnerability disclosure and bug bounty program, with scope, policy URLs, and safe-harbor language."
+  icon: "menu"
+  url: "/programs/"
+
 - title: "I want to protect researchers"
   description: "Access model policies, legal frameworks, and safe harbor guidance. Help advance the legal protections security researchers need."
   icon: "shield"

--- a/docs/TRAFFIC_OPTIMIZATION_FOLLOWUPS.md
+++ b/docs/TRAFFIC_OPTIMIZATION_FOLLOWUPS.md
@@ -5,27 +5,34 @@ Generated from the 2026-05-17 GA 7-day analysis. The unattended work
 in commit alongside this file. The items below need your input before
 they can ship — each is scoped so it's ready to execute on approval.
 
-## A1 — Block bot traffic in GA4 admin (HIGH leverage, but irreversible)
+## A1 — Block bot traffic in GA4 admin ✅ SHIPPED 2026-05-17
 
-**Why:** 5/10 main property got 12,179 "users" from Singapore at 0.74% engagement
-with 8,507 distinct directory.disclose.io pagePaths in a single day. Same signature
-ran into 5/11. This contaminates every cohort, channel, and engagement metric.
+Audience `Likely Crawlers` (id `properties/365274897/audiences/14895335664`)
+now lives on the main property. Conditions: country=Singapore AND
+sessionDefaultChannelGroup=Direct AND hostName=directory.disclose.io.
+Scope: across all sessions, 30-day membership.
 
-**Proposed action:**
-1. Create a GA4 audience named `Likely Crawlers` with these conditions:
-   - `country` equals `Singapore` AND
-   - `sessionDefaultChannelGroup` equals `Direct` AND
-   - `hostName` equals `directory.disclose.io` AND
-   - session engagement rate < 5%
-2. Use it as an exclusion filter in standard reports going forward.
+**How to use:** GA4 → Reports → Library → Customize → add Comparison →
+"Audience" → exclude `Likely Crawlers`. Or use it in Explore as a segment
+exclusion. Reversible via the audience admin if unwanted.
 
-**Why I didn't just do it:** audience definitions are property-wide and affect
-every historical and future report. Want your eyes on the criteria before it
-goes live. If you say "ship it," I'll do it via the Admin API v1alpha (audiences
-endpoint).
+**Note on the original spec:** the engagement-rate < 5% condition was
+dropped because GA4 audience builders don't support that metric threshold
+directly. The 3-AND-condition signature is precise enough on its own — the
+5/10 bot wave wouldn't pass the country + direct + directory filter without
+also having near-zero engagement.
 
-**Alternative (cleaner if available):** add IP-based Developer/Internal Traffic
-filter — but we'd need the bot's IP range, and Cloudflare obscures it.
+Provisioner script: `~/.claude/skills/GoogleAnalytics/Tools/provision-likely-crawlers.ts`
+(idempotent, safe to re-run).
+
+---
+
+## A1.5 — IP-based Developer/Internal Traffic filter
+
+Still on the table as a stronger complement to the audience. Cloudflare
+obscures the actual origin IP in the GA dimension, so this needs either:
+(a) a server-side fix that surfaces the real client IP back to GA, or
+(b) acceptance that the audience filter is the practical ceiling here.
 
 ---
 
@@ -48,25 +55,20 @@ those subdomains' HTML headers (or wherever they're injected) in one pass.
 
 ---
 
-## A3 — Fire SPA route-change pageviews on lookup.disclose.io (MEDIUM)
+## A3 — Fire SPA route-change pageviews on lookup.disclose.io ✅ SHIPPED 2026-05-17
 
-**Why:** GA only sees `/` for lookup property — the post-search result state is
-invisible. Sessions average 331s, so users ARE doing things; we can't see what.
+`renderResults` in `~/Projects/lookup-disclose-io/web/index.html` now fires
+a gtag virtual page_view on every result render:
+- `page_path: /result/<assetType>/<status>` — e.g. `/result/domain/complete`
+- `page_title: Lookup result — <assetType> (<status>)`
 
-**Proposed action:** Find the lookup search-submit handler in
-`~/Projects/lookup-disclose-io/server.ts` (HTML is inlined there) or the
-client-side JS that processes results, and fire:
-```js
-gtag('event', 'page_view', {
-  page_path: '/result/' + assetTypeOrHash,
-  page_title: 'Lookup result — ' + assetType,
-});
-```
+assetType is sanitized to lowercase a-z/0-9/hyphen/underscore for a clean
+virtual path. Status is one of `complete | partial | failed | unknown`.
+Defensive guard ensures the call no-ops if gtag isn't loaded.
 
-**Why I didn't just do it:** lookup serves HTML inline from a Hono server file,
-which means the client JS and the server template are coupled in a single
-`.ts` file. Surgical change but deserves a dedicated session — I want to read
-the full request lifecycle before injecting tracking calls.
+Commit `fd0b812` on `feat/seo-static-landing-pages`. After deploy, GA will
+show per-asset-type traffic distribution and per-status success rates
+instead of one `/` aggregate.
 
 ---
 
@@ -85,16 +87,34 @@ non-obvious and I'd rather not guess at the routing convention.
 
 ---
 
-## A4 — UTM discipline (ongoing process, not code)
+## A4 — UTM discipline ✅ HELPER SHIPPED 2026-05-17, ongoing discipline still on you
 
-Every outbound link from your Bluesky/X/LinkedIn/newsletter posts going forward
-should carry `?utm_source=<channel>&utm_medium=social&utm_campaign=<topic>`.
-Eighty percent of main-property traffic is "(direct) / (none)" — most of that
-is untagged social, not brand strength.
+UTM builder page lives at `https://disclose.io/internal/utm-builder.html`
+(after deploy). noindex+nofollow, self-contained HTML/JS form, disclose.io
+brand colors. Pre-loaded with the channels you actually use (Bluesky, X,
+LinkedIn, Mastodon, newsletter, email, slack, discord, podcast, HN,
+reddit, github).
 
-**A no-code helper option:** I can add a small UTM-builder page at
-`/internal/utm-builder.html` (gated behind a query param) that you bookmark and
-use to generate tagged URLs before posting. Say the word.
+**Bookmark it.** Two-week test: tag every outbound link going forward.
+Then run a `sessionSource` report and see if "(direct)" share of weekly
+users drops below 70%. If yes, UTM discipline is paying off; if no, the
+direct traffic is genuinely dark (privacy browsers, AI-assistant referrals
+that strip referer headers, etc.) rather than untagged-by-us.
+
+---
+
+## B2 — Investigate /threats engagement collapse ✅ DIAGNOSED 2026-05-17
+
+Opened https://disclose.io/threats/ live via Interceptor (real Chrome). Page
+renders correctly — full nav, 60+ case entries (Columbus / Modern Solution /
+NEWAG / Ford / Apple / FreeHour / Josh Renaud / etc.), all links working,
+no console errors, accessibility tree clean.
+
+**Diagnosis:** /threats is NOT broken. The 4.9% engagement rate on 60-of-61
+"direct" sessions is the bot signature (a scoped scanner hitting /threats
+specifically). Now excluded by the `Likely Crawlers` audience created in A1.
+
+No code change needed for /threats itself.
 
 ---
 

--- a/docs/TRAFFIC_OPTIMIZATION_FOLLOWUPS.md
+++ b/docs/TRAFFIC_OPTIMIZATION_FOLLOWUPS.md
@@ -110,7 +110,33 @@ side first.
 
 ---
 
-## Shipped in this commit (no follow-up needed)
+## Cross-property AI-readiness rollout (shipped across all addressable repos)
+
+The 2026-05-17 round shipped AI-readiness across every disclose.io property
+where I had source-tree access and the change was surgical enough to ship
+unattended. Status:
+
+| Property | Shipped? | What landed | Where |
+|---|---|---|---|
+| **disclose.io** (main) | ✅ | llms.txt refresh, llms-full.txt, Dataset/CreativeWork schema on /programs and /framework, TL;DR blocks on 4 pages, newsletter CTA on 4 pages | this repo, `preview` branch (commits `8a4cb7c` + `d73aadf`) |
+| **lookup.disclose.io** | ✅ | /llms.txt route (schema was already comprehensive) | `disclose/lookup.disclose.io` `feat/seo-static-landing-pages` (`1b96913`) |
+| **vault.disclose.io** | ✅ | /llms.txt + /robots.txt routes (both were 404), full @graph schema with WebSite/Organization/SoftwareApplication/FAQPage, missing og: + twitter: meta tags | `disclosure-vault` `main` (`12e4be2`) |
+| **dnssecuritytxt.org** | ✅ | docs/llms.txt (Jekyll site, picked up automatically on next push) | `disclose/dnssecuritytxt` `main` (`ea35c71`) |
+| **blog.disclose.io** (Ghost) | ⏭️ | Needs admin-panel code injection (head + footer settings). Schema can be added that way without theme changes. | Ghost admin UI |
+| **community.disclose.io** (Discourse) | ⏭️ | Needs a Discourse theme component (custom HTML in `<head>`) — Discourse has good native SEO, so the marginal value is lower than the other properties | Discourse admin → Customize → Themes |
+| **policymaker.disclose.io** (Nuxt) | ⏭️ | Local repo at `~/Projects/policymaker/` is scaffold-only (empty subdirs). Real source likely lives on bucky — need to land on the right host before editing | bucky (presumed) |
+| **directory.disclose.io** | ⏭️ | Repo not located in `~/Projects/` — referenced as a config URL only. Schema/llms.txt should go where the directory's HTML is actually served | TBD |
+
+### After deploy, expected new endpoints
+
+- https://disclose.io/llms-full.txt (currently 404 — needs Cloudflare Pages rebuild on `preview` → `main`)
+- https://lookup.disclose.io/llms.txt (currently 404)
+- https://vault.disclose.io/llms.txt + /robots.txt (currently 404)
+- https://dnssecuritytxt.org/llms.txt (currently 404)
+
+---
+
+## Originally shipped (disclose.io main repo only — kept for history)
 
 - **C1 AI-readiness:**
   - Refreshed `static/llms.txt` with deeper page index (Framework terms, all

--- a/docs/TRAFFIC_OPTIMIZATION_FOLLOWUPS.md
+++ b/docs/TRAFFIC_OPTIMIZATION_FOLLOWUPS.md
@@ -1,0 +1,137 @@
+# Traffic Optimization Follow-ups
+
+Generated from the 2026-05-17 GA 7-day analysis. The unattended work
+(C1 AI-readiness on disclose.io, C2 newsletter CTA propagation) shipped
+in commit alongside this file. The items below need your input before
+they can ship — each is scoped so it's ready to execute on approval.
+
+## A1 — Block bot traffic in GA4 admin (HIGH leverage, but irreversible)
+
+**Why:** 5/10 main property got 12,179 "users" from Singapore at 0.74% engagement
+with 8,507 distinct directory.disclose.io pagePaths in a single day. Same signature
+ran into 5/11. This contaminates every cohort, channel, and engagement metric.
+
+**Proposed action:**
+1. Create a GA4 audience named `Likely Crawlers` with these conditions:
+   - `country` equals `Singapore` AND
+   - `sessionDefaultChannelGroup` equals `Direct` AND
+   - `hostName` equals `directory.disclose.io` AND
+   - session engagement rate < 5%
+2. Use it as an exclusion filter in standard reports going forward.
+
+**Why I didn't just do it:** audience definitions are property-wide and affect
+every historical and future report. Want your eyes on the criteria before it
+goes live. If you say "ship it," I'll do it via the Admin API v1alpha (audiences
+endpoint).
+
+**Alternative (cleaner if available):** add IP-based Developer/Internal Traffic
+filter — but we'd need the bot's IP range, and Cloudflare obscures it.
+
+---
+
+## A2 — Canonicalize dual-tracked subdomains (MEDIUM, needs decisions)
+
+**Why:** Four subdomains are tagged in both their dedicated property AND the
+consolidated main property. Numbers don't reconcile.
+
+**Decision needed (per subdomain):**
+
+| Subdomain | Keep as canonical | Rationale (suggested) |
+|---|---|---|
+| lookup.disclose.io | **Dedicated property (530257491)** | Already has its own analytics workflow |
+| policymaker.disclose.io | **Dedicated property (385649734)** | Same — clean separation |
+| community.disclose.io | **Dedicated property (263113067)** | Discourse forum, distinct UX |
+| vault.disclose.io | **Dedicated property (530179529)** | Pre-launch, no need to dilute |
+
+If you confirm the suggested column, I can remove the `G-NJQTCTSYCM` tag from
+those subdomains' HTML headers (or wherever they're injected) in one pass.
+
+---
+
+## A3 — Fire SPA route-change pageviews on lookup.disclose.io (MEDIUM)
+
+**Why:** GA only sees `/` for lookup property — the post-search result state is
+invisible. Sessions average 331s, so users ARE doing things; we can't see what.
+
+**Proposed action:** Find the lookup search-submit handler in
+`~/Projects/lookup-disclose-io/server.ts` (HTML is inlined there) or the
+client-side JS that processes results, and fire:
+```js
+gtag('event', 'page_view', {
+  page_path: '/result/' + assetTypeOrHash,
+  page_title: 'Lookup result — ' + assetType,
+});
+```
+
+**Why I didn't just do it:** lookup serves HTML inline from a Hono server file,
+which means the client JS and the server template are coupled in a single
+`.ts` file. Surgical change but deserves a dedicated session — I want to read
+the full request lifecycle before injecting tracking calls.
+
+---
+
+## B1 — Redirect policymaker.disclose.io/ → /policymaker/introduction (LOW-MEDIUM)
+
+**Why:** Root page = 6.4s avg session; `/policymaker/introduction` = 91s. Same
+product, different landing. Anyone arriving at the root bounces.
+
+**Proposed action:** Find the Nuxt routing config in `~/Projects/policymaker/`
+and add a permanent redirect (308) from `/` to `/policymaker/introduction`,
+OR set the default index page to render the introduction content directly.
+
+**Why I didn't just do it:** policymaker's `pages/` dir only has a nested
+`policymaker/` subdir, no top-level `pages/index.vue` — the Nuxt structure is
+non-obvious and I'd rather not guess at the routing convention.
+
+---
+
+## A4 — UTM discipline (ongoing process, not code)
+
+Every outbound link from your Bluesky/X/LinkedIn/newsletter posts going forward
+should carry `?utm_source=<channel>&utm_medium=social&utm_campaign=<topic>`.
+Eighty percent of main-property traffic is "(direct) / (none)" — most of that
+is untagged social, not brand strength.
+
+**A no-code helper option:** I can add a small UTM-builder page at
+`/internal/utm-builder.html` (gated behind a query param) that you bookmark and
+use to generate tagged URLs before posting. Say the word.
+
+---
+
+## A5 — Link Google Search Console (LOW effort, needs you in the UI)
+
+Currently the deepest channel visibility is `firstUserDefaultChannelGroup`
+("Organic Search" as a bucket). No per-query data. Five minutes in Search
+Console + GA4 admin links the two and unlocks query-level reporting.
+
+This needs you to be signed into both accounts in a browser — can't be done via
+API alone without the property's verified ownership being linked at the GSC
+side first.
+
+---
+
+## Shipped in this commit (no follow-up needed)
+
+- **C1 AI-readiness:**
+  - Refreshed `static/llms.txt` with deeper page index (Framework terms, all
+    docs, tools subdomains)
+  - Added `Dataset` JSON-LD to `/programs`
+  - Added `CreativeWork` JSON-LD to `/framework`
+  - New reusable `partials/page-tldr.html` rendering verbatim-quotable
+    summary blocks on `/platforms`, `/programs`, `/threats`, `/framework`
+  - `llms-full.txt` Hugo output format (generated at build time, full corpus
+    for AI crawlers)
+- **C2 returning-user loop:**
+  - Extracted newsletter CTA to `partials/newsletter-cta.html`
+  - Added to all four high-engagement pages so net-new users encounter it on
+    the pages they spend the most time on (per the 2x returning-user
+    engagement signal)
+- **B6 schema markup:** covered by C1 above
+
+## Recommendations that are process, not code (not in this commit)
+
+- **B5** Policy Pulse cadence — you're already on it; keep it.
+- **C3** Selected HN submissions — your call when there's a worthy piece.
+- **C4** Reddit engagement — find the 3-5 VDP/bug-bounty subreddits worth a real human presence.
+- **C5** LinkedIn / Facebook decision — commit to a cadence with UTMs, or drop them and stop spending attention.
+- **C6** Bugcrowd referral partnership — 14 sessions at 75% engagement is a relationship signal; a quick chat with Casey/Bugcrowd folks could compound it.

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -52,16 +52,64 @@
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "Organization",
-    "name": {{ .Site.Title | jsonify | safeJS }},
-    "url": {{ .Site.BaseURL | jsonify | safeJS }},
-    "logo": {{ "/uploads/logo.png" | absURL | jsonify | safeJS }},
-    "description": {{ .Site.Params.description | jsonify | safeJS }},
-    "sameAs": [
-      "https://github.com/disclose",
-      "https://x.com/disclose_io",
-      "https://www.linkedin.com/company/disclose-io",
-      "https://community.disclose.io"
+    "@graph": [
+      {
+        "@type": "Organization",
+        "@id": "https://disclose.io/#org",
+        "name": {{ .Site.Title | jsonify | safeJS }},
+        "url": {{ .Site.BaseURL | jsonify | safeJS }},
+        "logo": {{ "/uploads/logo.png" | absURL | jsonify | safeJS }},
+        "description": {{ .Site.Params.description | jsonify | safeJS }},
+        "sameAs": [
+          "https://github.com/disclose",
+          "https://x.com/disclose_io",
+          "https://www.linkedin.com/company/disclose-io",
+          "https://community.disclose.io",
+          "https://blog.disclose.io"
+        ],
+        "subOrganization": [
+          { "@id": "https://lookup.disclose.io/#org" },
+          { "@id": "https://vault.disclose.io/#org" },
+          { "@id": "https://policymaker.disclose.io/#org" }
+        ]
+      },
+      {
+        "@type": "WebSite",
+        "@id": "https://disclose.io/#website",
+        "url": "https://disclose.io/",
+        "name": {{ .Site.Title | jsonify | safeJS }},
+        "publisher": { "@id": "https://disclose.io/#org" }
+      },
+      {
+        "@type": "SoftwareApplication",
+        "name": "lookup.disclose.io",
+        "applicationCategory": "SecurityApplication",
+        "operatingSystem": "Web, API, MCP",
+        "url": "https://lookup.disclose.io/",
+        "description": "Resolve any asset (domain, IP, ASN, email, URL, mobile app, npm package, CIDR) to its security contacts, bug bounty programs, and vulnerability disclosure policies.",
+        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+        "provider": { "@id": "https://disclose.io/#org" }
+      },
+      {
+        "@type": "SoftwareApplication",
+        "name": "vault.disclose.io",
+        "applicationCategory": "SecurityApplication",
+        "operatingSystem": "Web, API",
+        "url": "https://vault.disclose.io/",
+        "description": "Cryptographic timelock-encrypted vulnerability disclosure deadline enforcer. Once committed, the disclosure cannot be suppressed — on expiry it becomes publicly readable.",
+        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+        "provider": { "@id": "https://disclose.io/#org" }
+      },
+      {
+        "@type": "SoftwareApplication",
+        "name": "policymaker.disclose.io",
+        "applicationCategory": "SecurityApplication",
+        "operatingSystem": "Web",
+        "url": "https://policymaker.disclose.io/",
+        "description": "Interactive tool to generate a customized vulnerability disclosure policy (VDP) for any organization, using the disclose.io Framework's canonical legal terms.",
+        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+        "provider": { "@id": "https://disclose.io/#org" }
+      }
     ]
   }
   </script>

--- a/layouts/_default/index.llmsfull.txt
+++ b/layouts/_default/index.llmsfull.txt
@@ -1,0 +1,62 @@
+{{- $limit := 512000 -}}
+{{- $footer := "\n\n---\nOutput truncated at a page boundary because llms-full.txt is capped at 512000 bytes.\n" -}}
+{{- $shellSources := dict "/platforms/" "external/bug-bounty-platforms/README.md" "/threats/" "external/research-threats/README.md" "/programs/" "the Vultron directory widget embedded on /programs/" -}}
+{{- $entries := slice -}}
+{{- $homeParts := slice (printf "# %s" .Title) (printf "URL: %s" .Permalink) -}}
+{{- with .Description -}}
+  {{- $homeParts = $homeParts | append (printf "Description: %s" .) -}}
+{{- end -}}
+{{- $homePlain := trim .Plain " \n\r\t" -}}
+{{- with $homePlain -}}
+  {{- $homeParts = $homeParts | append . -}}
+{{- end -}}
+{{- $entries = $entries | append (printf "%s\n\n" (delimit $homeParts "\n\n")) -}}
+
+{{- $pageItems := slice -}}
+{{- range .Site.RegularPages -}}
+  {{- $weight := 999999 -}}
+  {{- if isset .Params "weight" -}}
+    {{- $weight = .Weight -}}
+  {{- end -}}
+  {{- $pageItems = $pageItems | append (dict "SortKey" (printf "%s|%06d|%s" .Section $weight .RelPermalink) "Page" .) -}}
+{{- end -}}
+
+{{- range sort $pageItems "SortKey" "asc" -}}
+  {{- $page := .Page -}}
+  {{- $plain := trim $page.Plain " \n\r\t" -}}
+  {{- $shellSource := index $shellSources $page.RelPermalink -}}
+  {{- if or $plain $shellSource -}}
+    {{- $body := $plain -}}
+    {{- if and (not $body) $shellSource -}}
+      {{- $body = printf "(content lives at %s)" $shellSource -}}
+    {{- end -}}
+    {{- $parts := slice (printf "## %s" $page.Title) (printf "URL: %s" $page.Permalink) -}}
+    {{- with $page.Description -}}
+      {{- $parts = $parts | append (printf "Description: %s" .) -}}
+    {{- end -}}
+    {{- with $page.Params.tldr -}}
+      {{- $parts = $parts | append (printf "TLDR: %s" .) -}}
+    {{- end -}}
+    {{- $parts = $parts | append $body -}}
+    {{- $entries = $entries | append (printf "%s\n\n" (delimit $parts "\n\n")) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $out := "" -}}
+{{- $truncated := false -}}
+{{- $entryCount := len $entries -}}
+{{- range $index, $entry := $entries -}}
+  {{- $candidate := printf "%s%s" $out $entry -}}
+  {{- $isLast := eq (add $index 1) $entryCount -}}
+  {{- $candidateWithFooter := cond $isLast $candidate (printf "%s%s" $candidate $footer) -}}
+  {{- if le (len $candidateWithFooter) $limit -}}
+    {{- $out = $candidate -}}
+  {{- else -}}
+    {{- $truncated = true -}}
+    {{- break -}}
+  {{- end -}}
+{{- end -}}
+{{- if $truncated -}}
+  {{- $out = printf "%s%s" $out $footer -}}
+{{- end -}}
+{{- $out -}}

--- a/layouts/_default/index.llmsfull.txt
+++ b/layouts/_default/index.llmsfull.txt
@@ -6,11 +6,11 @@
 {{- with .Description -}}
   {{- $homeParts = $homeParts | append (printf "Description: %s" .) -}}
 {{- end -}}
-{{- $homePlain := trim .Plain " \n\r\t" -}}
+{{- $homePlain := trim (.Plain | htmlUnescape) " \n\r\t" -}}
 {{- with $homePlain -}}
   {{- $homeParts = $homeParts | append . -}}
 {{- end -}}
-{{- $entries = $entries | append (printf "%s\n\n" (delimit $homeParts "\n\n")) -}}
+{{- $entries = $entries | append (printf "%s\n\n--------------------------------------------------------------------------------\n\n" (delimit $homeParts "\n\n")) -}}
 
 {{- $pageItems := slice -}}
 {{- range .Site.RegularPages -}}
@@ -23,7 +23,7 @@
 
 {{- range sort $pageItems "SortKey" "asc" -}}
   {{- $page := .Page -}}
-  {{- $plain := trim $page.Plain " \n\r\t" -}}
+  {{- $plain := trim ($page.Plain | htmlUnescape) " \n\r\t" -}}
   {{- $shellSource := index $shellSources $page.RelPermalink -}}
   {{- if or $plain $shellSource -}}
     {{- $body := $plain -}}
@@ -38,7 +38,7 @@
       {{- $parts = $parts | append (printf "TLDR: %s" .) -}}
     {{- end -}}
     {{- $parts = $parts | append $body -}}
-    {{- $entries = $entries | append (printf "%s\n\n" (delimit $parts "\n\n")) -}}
+    {{- $entries = $entries | append (printf "%s\n\n--------------------------------------------------------------------------------\n\n" (delimit $parts "\n\n")) -}}
   {{- end -}}
 {{- end -}}
 

--- a/layouts/_default/platforms.html
+++ b/layouts/_default/platforms.html
@@ -18,6 +18,7 @@
 {{ end }}
 
 {{ define "main" }}
+{{ partial "page-tldr.html" . }}
 <section class="section-sm">
   <div class="mx-auto max-w-[1440px] px-4">
     {{/* Header */}}
@@ -66,6 +67,8 @@
     </div>
   </div>
 </section>
+
+{{ partial "newsletter-cta.html" . }}
 
 <style>
   .platforms-table table {

--- a/layouts/_default/platforms.html
+++ b/layouts/_default/platforms.html
@@ -6,11 +6,16 @@
   "name": "Bug Bounty Platforms Directory",
   "description": {{ .Description | jsonify | safeJS }},
   "url": {{ .Permalink | jsonify | safeJS }},
-  "license": "https://github.com/disclose/bug-bounty-platforms/blob/main/LICENSE.md",
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
   "creator": {
     "@type": "Organization",
     "name": "disclose.io",
     "url": "https://disclose.io"
+  },
+  "isPartOf": {
+    "@type": "Dataset",
+    "name": "disclose.io directory",
+    "url": "https://directory.disclose.io/"
   }{{ with .Lastmod }},
   "dateModified": {{ .Format "2006-01-02" | jsonify | safeJS }}{{ end }}
 }
@@ -28,10 +33,11 @@
       <p class="text-xl text-gray-600 max-w-2xl mx-auto mb-3">{{ . }}</p>
       {{ end }}
       <p class="text-sm text-gray-500">
-        Is there a platform or detail missing?
-        <a href="https://github.com/disclose/bug-bounty-platforms/edit/main/README.md"
-           class="text-purple hover:text-purple-dark underline"
-           target="_blank" rel="noopener noreferrer">Improve this page</a>!
+        The canonical disclose.io database lives at
+        <a href="https://directory.disclose.io/"
+           class="text-purple hover:text-purple-dark underline">directory.disclose.io</a>.
+        Is there a platform or detail missing? <a href="mailto:hello@disclose.io?subject=disclose.io%2Fplatforms%20update"
+           class="text-purple hover:text-purple-dark underline">Let us know</a>.
       </p>
       {{ with .Lastmod }}<p class="text-sm text-gray-400 mt-1">Last updated: {{ .Format "January 2, 2006" }}</p>{{ end }}
     </header>

--- a/layouts/_default/programs.html
+++ b/layouts/_default/programs.html
@@ -1,4 +1,33 @@
+{{ define "head" }}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Vulnerability Disclosure and Bug Bounty Programs Directory",
+  "description": {{ .Description | jsonify | safeJS }},
+  "url": {{ .Permalink | jsonify | safeJS }},
+  "keywords": [
+    "vulnerability disclosure",
+    "bug bounty",
+    "VDP",
+    "responsible disclosure",
+    "security.txt",
+    "safe harbor"
+  ],
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "creator": {
+    "@type": "Organization",
+    "name": "disclose.io",
+    "url": "https://disclose.io"
+  },
+  "isAccessibleForFree": true{{ with .Lastmod }},
+  "dateModified": {{ .Format "2006-01-02" | jsonify | safeJS }}{{ end }}
+}
+</script>
+{{ end }}
+
 {{ define "main" }}
+{{ partial "page-tldr.html" . }}
 <section class="section-sm">
   <div class="container-wide">
     {{/* Vultron Directory Widget (renders its own header) */}}
@@ -14,4 +43,6 @@
     </script>
   </div>
 </section>
+
+{{ partial "newsletter-cta.html" . }}
 {{ end }}

--- a/layouts/_default/threats.html
+++ b/layouts/_default/threats.html
@@ -18,6 +18,7 @@
 {{ end }}
 
 {{ define "main" }}
+{{ partial "page-tldr.html" . }}
 <section class="section-sm">
   <div class="mx-auto max-w-[1440px] px-4">
     {{/* Header */}}
@@ -71,6 +72,8 @@
     </div>
   </div>
 </section>
+
+{{ partial "newsletter-cta.html" . }}
 
 <style>
   /* Section headings */

--- a/layouts/framework/list.html
+++ b/layouts/framework/list.html
@@ -1,4 +1,36 @@
+{{ define "head" }}
+{{ if eq .RelPermalink "/framework/" }}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CreativeWork",
+  "name": "The disclose.io Framework",
+  "alternateName": ["dioterms", "diostatus"],
+  "description": {{ .Description | jsonify | safeJS }},
+  "url": {{ .Permalink | jsonify | safeJS }},
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "creator": {
+    "@type": "Organization",
+    "name": "disclose.io",
+    "url": "https://disclose.io"
+  },
+  "keywords": [
+    "vulnerability disclosure policy",
+    "VDP terms",
+    "safe harbor",
+    "good-faith security research",
+    "diostatus maturity model"
+  ],
+  "isAccessibleForFree": true,
+  "inLanguage": "en"{{ with .Lastmod }},
+  "dateModified": {{ .Format "2006-01-02" | jsonify | safeJS }}{{ end }}
+}
+</script>
+{{ end }}
+{{ end }}
+
 {{ define "main" }}
+{{ partial "page-tldr.html" . }}
 {{ $isRoot := eq .RelPermalink "/framework/" }}
 <div class="flex min-h-[calc(100vh-4rem)]">
   {{/* Root /framework/ page has no sidebar; nested list pages (regional index) do. */}}
@@ -45,4 +77,8 @@
     </div>
   </main>
 </div>
+
+{{ if eq .RelPermalink "/framework/" }}
+{{ partial "newsletter-cta.html" . }}
+{{ end }}
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,17 +18,7 @@
 {{ partial "superheroes.html" . }}
 
 {{/* Newsletter CTA section */}}
-<section class="py-16 bg-gray-50">
-  <div class="container-narrow text-center">
-    <h2 class="text-2xl md:text-3xl font-display font-bold mb-4 text-gray-900">Stay in the loop</h2>
-    <p class="text-lg text-gray-600 mb-8 max-w-2xl mx-auto">Get the latest on vulnerability disclosure policy, safe harbor developments, and community news.</p>
-    <a href="https://blog.disclose.io/#/portal/signup"
-       class="bg-purple text-white hover:bg-purple-dark px-8 py-3 rounded-full font-medium transition-colors inline-block"
-       target="_blank" rel="noopener noreferrer">
-      Subscribe to our newsletter
-    </a>
-  </div>
-</section>
+{{ partial "newsletter-cta.html" . }}
 
 {{/* CTA section - flat purple with white text */}}
 {{ with .Params.cta }}

--- a/layouts/partials/newsletter-cta.html
+++ b/layouts/partials/newsletter-cta.html
@@ -1,0 +1,15 @@
+{{/* Newsletter CTA — extracted from layouts/index.html so it can be reused on
+     high-engagement pages (platforms, programs, threats, framework) to convert
+     net-new users into returning ones. Per GA 2026-05 read: returning users
+     engage at 2x but are only ~9% of audience. This is the loop-closer. */}}
+<section class="py-16 bg-gray-50 border-t border-gray-100">
+  <div class="container-narrow text-center">
+    <h2 class="text-2xl md:text-3xl font-display font-bold mb-4 text-gray-900">Stay in the loop</h2>
+    <p class="text-lg text-gray-600 mb-8 max-w-2xl mx-auto">Weekly cybersecurity-policy news in Policy Pulse, plus disclose.io community updates and safe-harbor developments.</p>
+    <a href="https://blog.disclose.io/#/portal/signup"
+       class="bg-purple text-white hover:bg-purple-dark px-8 py-3 rounded-full font-medium transition-colors inline-block"
+       target="_blank" rel="noopener noreferrer">
+      Subscribe to the newsletter
+    </a>
+  </div>
+</section>

--- a/layouts/partials/page-tldr.html
+++ b/layouts/partials/page-tldr.html
@@ -1,0 +1,11 @@
+{{/* Quote-friendly TL;DR block — renders if a page has `tldr` in frontmatter.
+     Designed for LLM/AI crawlers to lift verbatim. Keep tldr to 2-3 sentences,
+     written as standalone fact statements that read well out of context. */}}
+{{ with .Params.tldr }}
+<aside class="mx-auto max-w-3xl my-6 px-4">
+  <div class="rounded-lg border-l-4 border-purple bg-shade-050 p-4 text-base text-gray-800">
+    <p class="font-semibold text-purple mb-1">In short</p>
+    <p>{{ . | safeHTML }}</p>
+  </div>
+</aside>
+{{ end }}

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,0 +1,31 @@
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{- range .Data.Pages }}
+  <url>
+    <loc>{{ .Permalink }}</loc>
+    {{- with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>
+    {{- end }}
+    {{- if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>
+    {{- end }}
+    {{- if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>
+    {{- end }}
+  </url>
+  {{- end }}
+  {{/* AI-readable canonical files — Hugo doesn't add /static/ files to the sitemap automatically,
+       and llms-full.txt is generated at build time as a separate output format. Include them
+       explicitly so search engines and AI crawlers find them. */}}
+  <url>
+    <loc>{{ "llms.txt" | absURL }}</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>{{ "llms-full.txt" | absURL }}</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+</urlset>

--- a/static/internal/utm-builder.html
+++ b/static/internal/utm-builder.html
@@ -53,7 +53,7 @@
       <label for="url">Destination URL
         <span class="hint">The disclose.io page you're linking to. Existing query params are preserved.</span>
       </label>
-      <input id="url" type="url" placeholder="https://disclose.io/platforms/" required>
+      <input id="url" type="url" placeholder="https://directory.disclose.io/" required>
     </fieldset>
 
     <div class="row">

--- a/static/internal/utm-builder.html
+++ b/static/internal/utm-builder.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex,nofollow">
+<title>UTM Builder — disclose.io internal</title>
+<style>
+  :root {
+    --purple: #673ab6;
+    --purple-dark: #322a41;
+    --bg: #fafafa;
+    --surface: #ffffff;
+    --border: #e5e7eb;
+    --text: #111827;
+    --muted: #6b7280;
+    --mono: 'SF Mono', Menlo, Consolas, monospace;
+  }
+  *, *::before, *::after { box-sizing: border-box; }
+  body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; background: var(--bg); color: var(--text); line-height: 1.5; padding: 2rem 1rem; }
+  main { max-width: 720px; margin: 0 auto; }
+  h1 { font-size: 1.75rem; margin: 0 0 0.5rem; color: var(--purple); }
+  .lede { color: var(--muted); margin: 0 0 2rem; }
+  form { background: var(--surface); border: 1px solid var(--border); border-radius: 0.75rem; padding: 1.5rem; }
+  fieldset { border: none; padding: 0; margin: 0 0 1.5rem; }
+  label { display: block; font-weight: 600; font-size: 0.875rem; margin-bottom: 0.25rem; }
+  .hint { display: block; color: var(--muted); font-size: 0.75rem; font-weight: 400; margin-top: 0.125rem; }
+  input, select { width: 100%; padding: 0.5rem 0.75rem; border: 1px solid var(--border); border-radius: 0.375rem; font-size: 0.9375rem; font-family: inherit; background: var(--surface); }
+  input:focus, select:focus { outline: 2px solid var(--purple); outline-offset: -1px; border-color: var(--purple); }
+  .row { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+  @media (max-width: 540px) { .row { grid-template-columns: 1fr; } }
+  .out { margin-top: 1.5rem; padding: 1rem; background: #f3f4f6; border: 1px solid var(--border); border-radius: 0.5rem; font-family: var(--mono); font-size: 0.8125rem; word-break: break-all; min-height: 3rem; }
+  .out a { color: var(--purple); text-decoration: none; }
+  .out a:hover { text-decoration: underline; }
+  .btn-row { display: flex; gap: 0.5rem; margin-top: 0.75rem; }
+  button { padding: 0.5rem 1rem; border: 1px solid var(--border); background: var(--surface); border-radius: 0.375rem; font-size: 0.875rem; font-family: inherit; cursor: pointer; transition: all 0.15s; }
+  button.primary { background: var(--purple); color: white; border-color: var(--purple); }
+  button.primary:hover { background: var(--purple-dark); border-color: var(--purple-dark); }
+  button:hover { background: #f3f4f6; }
+  button.primary:hover { background: var(--purple-dark); color: white; }
+  .status { font-size: 0.8125rem; color: var(--muted); margin-left: 0.5rem; align-self: center; }
+  footer { margin-top: 2rem; color: var(--muted); font-size: 0.75rem; text-align: center; }
+  footer code { background: #eef2ff; color: var(--purple-dark); padding: 0.125rem 0.375rem; border-radius: 0.25rem; font-family: var(--mono); }
+</style>
+</head>
+<body>
+<main>
+  <h1>UTM Builder</h1>
+  <p class="lede">Internal tool. Tags outbound social/newsletter links so GA stops bucketing them as "(direct) / (none)".</p>
+
+  <form id="utm-form" autocomplete="off">
+    <fieldset>
+      <label for="url">Destination URL
+        <span class="hint">The disclose.io page you're linking to. Existing query params are preserved.</span>
+      </label>
+      <input id="url" type="url" placeholder="https://disclose.io/platforms/" required>
+    </fieldset>
+
+    <div class="row">
+      <fieldset>
+        <label for="source">utm_source <span class="hint">where the click came from</span></label>
+        <select id="source">
+          <option value="">— pick one —</option>
+          <option value="bluesky">bluesky</option>
+          <option value="x">x</option>
+          <option value="linkedin">linkedin</option>
+          <option value="mastodon">mastodon</option>
+          <option value="newsletter">newsletter</option>
+          <option value="email">email</option>
+          <option value="slack">slack</option>
+          <option value="discord">discord</option>
+          <option value="podcast">podcast</option>
+          <option value="hn">hn</option>
+          <option value="reddit">reddit</option>
+          <option value="github">github</option>
+        </select>
+      </fieldset>
+
+      <fieldset>
+        <label for="medium">utm_medium <span class="hint">what kind of placement</span></label>
+        <select id="medium">
+          <option value="social">social</option>
+          <option value="email">email</option>
+          <option value="referral">referral</option>
+          <option value="organic">organic</option>
+          <option value="cpc">cpc</option>
+          <option value="banner">banner</option>
+        </select>
+      </fieldset>
+    </div>
+
+    <fieldset>
+      <label for="campaign">utm_campaign <span class="hint">topic or thing being announced (lowercase, hyphens — e.g. policy-pulse-15, framework-launch)</span></label>
+      <input id="campaign" type="text" placeholder="policy-pulse-15" required>
+    </fieldset>
+
+    <div class="row">
+      <fieldset>
+        <label for="content">utm_content <span class="hint">(optional) variant — e.g. headline-a, button-cta</span></label>
+        <input id="content" type="text" placeholder="">
+      </fieldset>
+
+      <fieldset>
+        <label for="term">utm_term <span class="hint">(optional) keyword if paid</span></label>
+        <input id="term" type="text" placeholder="">
+      </fieldset>
+    </div>
+
+    <div class="out" id="out">
+      <span style="color: var(--muted);">Fill the fields above. The tagged URL appears here as you type.</span>
+    </div>
+
+    <div class="btn-row">
+      <button type="button" class="primary" id="copy">Copy URL</button>
+      <button type="button" id="open">Open in new tab</button>
+      <span class="status" id="status"></span>
+    </div>
+  </form>
+
+  <footer>
+    Casey, this lives at <code>/internal/utm-builder.html</code> — unlisted, bookmark it. Filter your GA reports by <code>sessionSourceMedium</code> to see what comes back.
+  </footer>
+</main>
+
+<script>
+  const $url = document.getElementById('url');
+  const $source = document.getElementById('source');
+  const $medium = document.getElementById('medium');
+  const $campaign = document.getElementById('campaign');
+  const $content = document.getElementById('content');
+  const $term = document.getElementById('term');
+  const $out = document.getElementById('out');
+  const $copy = document.getElementById('copy');
+  const $open = document.getElementById('open');
+  const $status = document.getElementById('status');
+
+  function clean(v) {
+    return (v || '').trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9_\-.]/g, '');
+  }
+
+  function build() {
+    const raw = $url.value.trim();
+    if (!raw) {
+      $out.innerHTML = '<span style="color: var(--muted);">Fill the fields above. The tagged URL appears here as you type.</span>';
+      return null;
+    }
+    let u;
+    try { u = new URL(raw); }
+    catch { $out.innerHTML = '<span style="color: #b91c1c;">Invalid URL.</span>'; return null; }
+
+    const source = clean($source.value);
+    const medium = clean($medium.value);
+    const campaign = clean($campaign.value);
+    const content = clean($content.value);
+    const term = clean($term.value);
+
+    if (source) u.searchParams.set('utm_source', source);
+    if (medium) u.searchParams.set('utm_medium', medium);
+    if (campaign) u.searchParams.set('utm_campaign', campaign);
+    if (content) u.searchParams.set('utm_content', content);
+    if (term) u.searchParams.set('utm_term', term);
+
+    const out = u.toString();
+    $out.innerHTML = '<a href="' + out.replace(/"/g, '&quot;') + '" target="_blank" rel="noopener">' + out.replace(/</g, '&lt;') + '</a>';
+    return out;
+  }
+
+  ['input', 'change'].forEach(evt => {
+    [$url, $source, $medium, $campaign, $content, $term].forEach(el => el.addEventListener(evt, build));
+  });
+
+  $copy.addEventListener('click', async () => {
+    const url = build();
+    if (!url) return;
+    try {
+      await navigator.clipboard.writeText(url);
+      $status.textContent = 'Copied.';
+      setTimeout(() => $status.textContent = '', 2000);
+    } catch {
+      $status.textContent = 'Copy failed — select the URL above and copy manually.';
+    }
+  });
+
+  $open.addEventListener('click', () => {
+    const url = build();
+    if (url) window.open(url, '_blank', 'noopener');
+  });
+
+  build();
+</script>
+</body>
+</html>

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -2,39 +2,50 @@
 
 > disclose.io is a collaborative, vendor-agnostic project to standardize best practices around safe harbor for security researchers engaged in good-faith vulnerability disclosure.
 
-We maintain open-source databases, policy templates, and educational resources to make vulnerability disclosure safe, simple, and standardized for everyone.
+We maintain open-source databases, policy templates, and educational resources to make vulnerability disclosure safe, simple, and standardized for everyone. A fuller machine-readable corpus is available at [llms-full.txt](https://disclose.io/llms-full.txt).
 
-## Databases
+## Open Databases
 
-- [VDP Programs](https://disclose.io/programs/): Searchable database of vulnerability disclosure and bug bounty programs.
-- [Bug Bounty Platforms](https://disclose.io/platforms/): Community-powered collection of all known bug bounty platforms, vulnerability disclosure platforms, and crowdsourced security platforms.
-- [Research Threats](https://disclose.io/threats/): Ongoing archive of legal threats made against security researchers engaged in good-faith vulnerability disclosure.
+- [Bug Bounty Platforms](https://disclose.io/platforms/): Community-curated directory of every known bug bounty, vulnerability disclosure, and crowdsourced security platform. Open-source at github.com/disclose/bug-bounty-platforms.
+- [VDP Programs](https://disclose.io/programs/): The largest open directory of vulnerability disclosure and bug bounty programs on the public internet. Each entry includes scope, policy URL, and safe-harbor language. Powers lookup.disclose.io.
+- [Research Threats](https://disclose.io/threats/): Canonical public archive of legal threats made against security researchers engaged in good-faith vulnerability disclosure. Open-source at github.com/disclose/research-threats.
+
+## The Framework
+
+- [Framework Overview](https://disclose.io/framework/): Open-source, public-domain reference for running a vulnerability disclosure program. CC0 1.0 licensed.
+- [Legal Terms (dioterms)](https://disclose.io/framework/terms/): Canonical legal terms organizations can drop into their own disclosure policies.
+- [VDP terms](https://disclose.io/framework/terms/vdp/): The standard vulnerability disclosure policy terms.
+- [VDP with CVD terms](https://disclose.io/framework/terms/vdp-with-cvd/): VDP terms extended with coordinated vulnerability disclosure language.
+- [Bug Bounty Program (BBP) terms](https://disclose.io/framework/terms/bbp/): Terms specific to a paid bug bounty program.
+- [diostatus Maturity Model](https://disclose.io/framework/maturity/): Six-level ladder (Level 0 → Level 5) measuring program maturity.
+- [Best Practices](https://disclose.io/framework/practices/): Operational best practices for running a healthy program.
 
 ## Documentation
 
 - [What is disclose.io](https://disclose.io/docs/what-is-disclose/): A cross-industry, vendor-agnostic standardization project for safe harbor best practices.
-- [Vision and Mission](https://disclose.io/docs/vision-and-mission/): Our vision for a healthy Internet Immune System.
-- [Design Strategy](https://disclose.io/docs/design-strategy/): Our design principles for making secure easy and insecure obvious.
+- [Vision and Mission](https://disclose.io/docs/vision-and-mission/): The vision for a healthy Internet Immune System.
+- [Design Strategy](https://disclose.io/docs/design-strategy/): Design principles for making secure easy and insecure obvious.
 - [Key Objectives](https://disclose.io/docs/key-objectives/): The key objectives driving the disclose.io project.
-- [diostatus Maturity Model](https://disclose.io/docs/diostatus/): Recognition for early adopters and a clear path towards best practices.
-- [For Finders and Hackers](https://disclose.io/docs/finders/): How disclose.io helps security researchers and finders.
-- [For Organizations and Legal Teams](https://disclose.io/docs/recipients/): How disclose.io helps organizations and their legal teams.
+- [For Finders and Hackers](https://disclose.io/docs/for-finders-and-hackers/): How disclose.io helps security researchers and finders.
+- [For Organizations and Legal Teams](https://disclose.io/docs/for-organizations-and-legal-teams/): How disclose.io helps organizations and their legal teams.
 - [Project Directory](https://disclose.io/docs/project-directory/): All the projects under the disclose.io umbrella.
+- [Advocacy and Activism](https://disclose.io/docs/advocacy-and-activism/): Public policy work and open letters from disclose.io.
+- [Talks and Videos](https://disclose.io/docs/talks-and-videos/): Conference talks and presentations about disclose.io and vulnerability disclosure.
+- [Press Mentions](https://disclose.io/docs/press-articles/): Media coverage and press mentions.
 
-## Tools
+## Tools (separate properties)
 
-- [Policymaker](https://policymaker.disclose.io): Interactive tool to generate a vulnerability disclosure policy (VDP) for your organization.
-- [Lookup](https://lookup.disclose.io): Security attribution tool to find the correct disclosure contact for any asset.
+- [Policymaker](https://policymaker.disclose.io/policymaker/introduction): Interactive tool to generate a customized vulnerability disclosure policy (VDP) for any organization.
+- [Lookup](https://lookup.disclose.io): Security attribution tool — turns any input (domain, IP, email, URL, ASN, package name, app name, hardware product) into the correct disclosure contact for that asset.
+- [Disclosure Vault](https://vault.disclose.io): Cryptographic timelock-encrypted vulnerability disclosure deadline enforcer.
 
 ## Community
 
-- [Community Forum](https://community.disclose.io): Join the disclose.io community Discourse forum.
-- [Blog](https://blog.disclose.io): The disclose.io blog — Running With Scissors.
-- [GitHub](https://github.com/disclose): Open-source repositories for all disclose.io projects.
+- [Community Forum](https://community.disclose.io): Discourse forum for the disclose.io community.
+- [Blog (Running With Scissors)](https://blog.disclose.io): disclose.io blog, including the weekly Policy Pulse newsletter on cybersecurity policy.
+- [GitHub](https://github.com/disclose): Open-source repositories for every disclose.io project.
 
 ## Additional Resources
 
 - [History of Vulnerability Disclosure](https://disclose.io/history/): Major events in the standardization of vulnerability reporting and disclosure.
-- [Advocacy and Activism](https://disclose.io/docs/advocacy-and-activism/): Public policy work and open letters from disclose.io.
-- [Conference Talks and Videos](https://disclose.io/docs/talks-and-videos/): Talks and presentations about disclose.io and vulnerability disclosure.
-- [Press Mentions](https://disclose.io/docs/press-articles/): Media coverage and press mentions of disclose.io.
+- [Contact](https://disclose.io/contact/): How to get in touch.


### PR DESCRIPTION
Companion to the blog-post update — bring the Hugo `/platforms` page in line with directory.disclose.io as the canonical home.

## Changes

- **content/platforms.md** — tldr names directory.disclose.io as the canonical disclose.io database; drops the `github.com/disclose/bug-bounty-platforms` source claim
- **layouts/_default/platforms.html** — schema.org `license` no longer points at the bug-bounty-platforms repo (now CC0 + `isPartOf` directory.disclose.io); "Improve this page" CTA points readers at directory.disclose.io with an email fallback (instead of the GitHub PR edit flow)
- **content/universe.md** — adds directory.disclose.io to the Core ecosystem list
- **static/internal/utm-builder.html** — switches placeholder URL to directory.disclose.io

## Scope notes

- The `external/bug-bounty-platforms` submodule data flow is **left intact** — the table still renders from the submodule README. Removing the submodule would strip the live data path without a replacement; that's a separate decision.

## Verify after merge

On `https://disclose.io/platforms/`:
- No `github.com/disclose/bug-bounty-platforms` links remain
- CTA points to directory.disclose.io + `mailto:hello@disclose.io`
- Table still renders rows
