### PR TITLE
framework: bbp→terms/bbp path + bump dioterms pin (Phase A+B)

### DIFF
--- a/scripts/preprocess-framework.js
+++ b/scripts/preprocess-framework.js
@@ -31,7 +31,7 @@ const TERMS = [
   { src: 'terms/vdp-with-cvd/en-US.md',       out: 'terms/vdp-with-cvd.md',       title: 'VDP with Coordinated Disclosure Window',  description: 'Canonical VDP with an explicit coordinated-disclosure timeline.',                          weight: 15 },
   { src: 'terms/safe-harbor/en-US.md',        out: 'terms/safe-harbor.md',        title: 'Safe Harbor',                             description: 'Standalone full safe-harbor clause for attaching to an existing policy.',                  weight: 20 },
   { src: 'terms/simple-safe-harbor/en-US.md', out: 'terms/simple-safe-harbor.md', title: 'Simple Safe Harbor',                      description: 'Condensed safe harbor clause for quick adoption.',                                         weight: 25 },
-  { src: 'bbp/en-US.md',                      out: 'terms/bbp.md',                title: 'Bug Bounty Program Policy',               description: 'Canonical BBP boilerplate with rewards structure and safe harbor.',                        weight: 30 },
+  { src: 'terms/bbp/en-US.md',                      out: 'terms/bbp.md',                title: 'Bug Bounty Program Policy',               description: 'Canonical BBP boilerplate with rewards structure and safe harbor.',                        weight: 30 },
 ];
 
 // Pillar 3: Practices — operational conduct guidance. External authors retain


### PR DESCRIPTION
Pairs with disclose/dioterms #16 (Phase B). Two changes:
1. `scripts/preprocess-framework.js`: BBP source `bbp/en-US.md` → `terms/bbp/en-US.md` (dioterms moved it under `terms/`).
2. Bump `external/dioterms` submodule pin `97ca1d0` → `9fa11f6` (Phase A provenance headers + Phase B structure).

**Rendered output is unchanged** — verified by running `preprocess-framework.js` against the new pinned content: all 12 framework pages regenerate cleanly (bbp from the new path); the only source-level delta vs. baseline is the invisible `<!-- Provenance -->` HTML comments added in Phase A. No visible change to disclose.io/framework/.