### PR TITLE
Repoint program-submission docs from diodb to directory.disclose.io

### DIFF
--- a/content/docs/contributors.md
+++ b/content/docs/contributors.md
@@ -215,9 +215,9 @@ Folks who have shipped meaningful commits across the [disclose.io GitHub org](ht
 
 Here are some of the ways you can contribute back:
 
-### Keeping diodb up-to-date
+### Keeping the directory up-to-date
 
-Help us maintain [diodb](https://github.com/disclose/diodb/blob/master/program-list.json) as the most comprehensive source of truth. Send us changes or additions to VDPs and bug bounty programs via PR to our Github repo.
+Help us keep [directory.disclose.io](https://directory.disclose.io) — the live system of record — comprehensive and current. Add or update VDPs and bug bounty programs directly in the directory. (The legacy [diodb](https://github.com/disclose/diodb) dataset is archived and read-only.)
 
 ### Help us translate policies
 

--- a/content/docs/project-directory.md
+++ b/content/docs/project-directory.md
@@ -60,11 +60,11 @@ A Go-based scanner that validates security.txt files at internet scale. Powers t
 
 Tracking adoption, documenting threats, and building the evidence base for policy work.
 
-### diodb: The VDP/BBP Database
+### The program directory
 
-The definitive community-powered database of every known vulnerability disclosure program and public bug bounty program, along with their disclose.io maturity status. The most active project in the ecosystem, contributions welcome via pull request.
+[directory.disclose.io](https://directory.disclose.io) is the live, community-powered system of record for every known vulnerability disclosure program and public bug bounty program, along with their disclose.io maturity status. Add or update a program directly in the directory.
 
-[Repository](https://github.com/disclose/diodb)
+The legacy [diodb](https://github.com/disclose/diodb) dataset — the original open-data prototype — is archived and read-only.
 
 ### Data survey: retired
 

--- a/content/docs/recipients.md
+++ b/content/docs/recipients.md
@@ -29,6 +29,6 @@ weight: 70
 
 1. *Whether you're starting from scratch or updating an existing policy, choose the legal terms that best fit your vulnerability disclosure program (VDP) or bug bounty program (BBP).*
 2. *Publish your new policy, or add the safe harbor terms to your existing VDP or BBP policy.*
-3. *Submit a pull request to add your program to the open-source disclose.io program database. The diodb maintainers will confirm details, validate your disclose.io status, and merge your request.*
+3. *Add your program to the disclose.io directory at [directory.disclose.io](https://directory.disclose.io) — the live system of record. The disclose.io team will confirm details and validate your disclose.io status.*
 4. *Select the appropriate disclose.io Seal based on your Disclose.io Status.*
 5. *Add the seal to your security page, vulnerability policy or reporting page, checkout page, and whatever else you like and let the world know you're joining the mission!*


### PR DESCRIPTION
diodb is being archived (read-only) — directory.disclose.io is the live system of record. This updates the contributor/recipient docs that still tell people to "submit a PR to diodb" (which can no longer be merged once archived):

- `recipients.md` — step 3 now points to directory.disclose.io.
- `contributors.md` — "Keeping diodb up-to-date" → "Keeping the directory up-to-date"; notes diodb is archived.
- `project-directory.md` — "diodb: The VDP/BBP Database" → "The program directory" (directory as system of record; diodb reframed as archived legacy prototype).

Companion to disclose/diodb#499 and disclose/dioterms#19. Targets `preview`.

**Not touched here (follow-up):** the legacy `static/standalone/programs-datatable-standalone.html` still `getJSON`s the raw diodb `program-list.json`. That is **non-breaking under archive** (the repo stays public, raw URL keeps serving 200 — just frozen data). Repointing it to the directory backend needs the directory's data-API contract, so it's a separate change, not a blind swap.