### PR TITLE
threats: unify page UX/UI with the site design system

### DIFF
--- a/STYLE-GUIDE.md
+++ b/STYLE-GUIDE.md
@@ -226,4 +226,32 @@ This single sentence validates researchers (protection) AND organizations (confi
 
 ---
 
+## Visual & UI Consistency
+
+The site's visual language lives in `tailwind.config.js` (colors: `purple` #673ab6, `shade-050..900`; `font-display` = Noto Sans Display) and the component classes in `assets/css/main.css` (notably `.card` = white / `rounded-xl` / `shadow-sm` / `border-shade-200`). Compose these tokens; do not invent one-off colors, radii, or shadows.
+
+### Table / directory pages (platforms, threats)
+
+Pages that render a large table from a submodule README (`layouts/_default/platforms.html`, `layouts/_default/threats.html`) follow one shared convention so they read as one system:
+
+- **Contain the content** to `max-w-6xl`, never `max-w-[1440px]` (edge-to-edge reads as an unstyled data dump).
+- **Card the tables.** Each logical table uses the `.card` treatment (white, `rounded-xl`, `border-shade-200`, `shadow-sm`, `overflow-hidden`). On platforms each category is its own card; on threats each incident table is a card.
+- **Section headers** are purple `font-display` (the site h2/h3 convention), not plain gray. Platforms adds a per-card platform-count badge.
+- **Soft table chrome:** uppercase `gray-600` labels on `shade-050`, `shade-100` row borders, `shade-050` hover tint. No sticky headers; no hard black-on-gray.
+- **Columns are per-page:** platforms cells are compact and truncate with shared `th` widths so all sections align; threats keeps the narrative `Status` column wrapping (never truncate prose) and mutes/emphasizes by column position.
+- Jump-nav (platforms) is pill chips rebuilt from the section list so anchor ids always match; `scroll-mt-24` clears the fixed navbar.
+
+### Acceptance gates (verify before shipping any table-page change)
+
+1. **Data conserved:** rendered row count == source README row count (nothing dropped by extraction/rendering).
+2. **Contrast ≥ WCAG AA 4.5:1** on every new text/background pair. Compute it: tokens frequently miss AA (`gray-500` on `shade-050` is 4.38:1, use `gray-600`).
+3. **No prose truncation** where a cell holds narrative (threats `Status`); short-data cells may truncate.
+4. **Mobile:** wide tables scroll inside their card; the page body must not scroll horizontally.
+5. **Verify against a FULL production build** (`npm run build` = prebuild + `build:css --minify` + hugo + pagefind), not `hugo server` — the dev server throws a `PagefindUI is not defined` console error and skips Tailwind purge.
+6. **After deploy, cache-bust before trusting the render:** `/css/main.css` is unfingerprinted, so a browser that visited earlier serves stale CSS — hard-reload (cmd+shift+r) or `curl https://disclose.io/css/main.css` and grep for the new classes. Also: the GitHub Pages deploy step can transiently fail with "Deployment failed, try again later" — re-run it (`gh run rerun <id> --failed`), it is not a code problem.
+
+**Footgun:** column emphasis/sizing by `nth-child` is positional — it only works if every table on the page shares the same column *order* (threats' 4 tables all run When / Entity / Researcher / Topic / Status even though their headers differ).
+
+---
+
 *This style guide reflects disclose.io's commitment to being accessible across diverse audiences while maintaining professional authority in the vulnerability disclosure space.*

--- a/layouts/_default/threats.html
+++ b/layouts/_default/threats.html
@@ -20,7 +20,7 @@
 {{ define "main" }}
 {{ partial "page-tldr.html" . }}
 <section class="section-sm">
-  <div class="mx-auto max-w-[1440px] px-4">
+  <div class="mx-auto max-w-6xl px-4">
     {{/* Header */}}
     <header class="mb-8 text-center">
       <h1 class="text-3xl md:text-4xl font-display font-bold mb-4">{{ .Title }}</h1>
@@ -62,7 +62,7 @@
     {{/* Render markdown */}}
     {{ $rendered := $content | markdownify }}
 
-    {{/* Clean up display text in links */}}
+    {{/* Clean up display text in links (href untouched) */}}
     {{ $rendered = $rendered | replaceRE `>https://www\.` `>` }}
     {{ $rendered = $rendered | replaceRE `>https://` `>` }}
     {{ $rendered = $rendered | replaceRE `>http://` `>` }}
@@ -76,104 +76,79 @@
 {{ partial "newsletter-cta.html" . }}
 
 <style>
-  /* Section headings */
-  .threats-content h3 {
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: #111827;
-    margin: 2rem 0 1rem;
-    padding-bottom: 0.5rem;
-    border-bottom: 2px solid #673ab6;
+  /* Descriptive intro + notes prose between the tables */
+  .threats-content > p {
+    color: #4b5563;                 /* gray-600 */
+    font-size: 0.9375rem;
+    line-height: 1.7;
+    margin: 2.25rem 0 0.75rem;
+    max-width: 75ch;
   }
-  .threats-content h3:first-child {
-    margin-top: 0;
-  }
-
-  /* Prose text between tables */
-  .threats-content > p,
+  .threats-content > p:first-child { margin-top: 0; }
   .threats-content > ul {
     color: #4b5563;
-    font-size: 0.875rem;
-    line-height: 1.625;
-    margin: 0.75rem 0;
-    max-width: 80ch;
-  }
-  .threats-content > ul {
+    font-size: 0.9375rem;
+    line-height: 1.7;
+    margin: 0.5rem 0 0.75rem;
     padding-left: 1.5rem;
     list-style-type: disc;
+    max-width: 75ch;
   }
+  .threats-content > ul li { margin: 0.25rem 0; }
 
-  /* Table wrapper, card style matching platforms */
+  /* Each incident table rendered as an on-brand card (matches .card token + /platforms) */
   .threats-content table {
     width: 100%;
     border-collapse: collapse;
     font-size: 0.8125rem;
-    margin: 1rem 0 2rem;
-    background: white;
-    border-radius: 0.5rem;
+    margin: 1rem 0 2.5rem;
+    background: #ffffff;
+    border: 1px solid hsla(229, 5%, 89%, 1);          /* shade-200 */
+    border-radius: 0.75rem;                            /* rounded-xl */
+    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);        /* shadow-sm */
     overflow: hidden;
-    box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
   }
 
-  /* Table headers, sticky */
   .threats-content thead th {
-    background: hsla(240, 8%, 97%, 1);
-    color: #111827;
+    background: hsla(240, 8%, 97%, 1);                 /* shade-050 */
+    color: #4b5563;                                    /* gray-600 */
     font-weight: 600;
+    font-size: 0.6875rem;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
     text-align: left;
-    padding: 0.625rem 0.75rem;
-    border-bottom: 2px solid hsla(229, 5%, 89%, 1);
-    position: sticky;
-    top: 0;
-    z-index: 1;
+    padding: 0.625rem 0.875rem;
+    border-bottom: 1px solid hsla(229, 5%, 89%, 1);    /* shade-200 */
     white-space: nowrap;
   }
 
-  /* Table cells */
   .threats-content tbody td {
-    padding: 0.5rem 0.75rem;
-    border-bottom: 1px solid hsla(240, 5%, 93%, 1);
+    padding: 0.625rem 0.875rem;
+    border-bottom: 1px solid hsla(240, 5%, 93%, 1);    /* shade-100 */
     vertical-align: top;
+    color: #374151;                                    /* gray-700 */
+    line-height: 1.6;
   }
-  .threats-content tbody tr:last-child td {
-    border-bottom: none;
-  }
-  .threats-content tbody tr:hover {
-    background: hsla(240, 8%, 97%, 1);
-  }
+  .threats-content tbody tr:last-child td { border-bottom: none; }
+  .threats-content tbody tr:hover { background: hsla(240, 8%, 97%, 0.6); }
+  .threats-content th:first-child,
+  .threats-content td:first-child { padding-left: 1.25rem; }
+  .threats-content th:last-child,
+  .threats-content td:last-child { padding-right: 1.25rem; }
 
-  /* Column widths, When/Entity/Researcher/Topic compact, Status gets space */
-  .threats-content td:nth-child(1) { /* When */
-    white-space: nowrap;
-    width: 7rem;
-  }
-  .threats-content td:nth-child(2) { /* Entity */
-    width: 10rem;
-  }
-  .threats-content td:nth-child(3) { /* Researcher(s) */
-    width: 10rem;
-  }
-  .threats-content td:nth-child(4) { /* Topic */
-    width: 14rem;
-  }
-  .threats-content td:nth-child(5) { /* Status, gets remaining space, word-wrap */
-    word-wrap: break-word;
-    overflow-wrap: break-word;
-    min-width: 20rem;
-  }
+  /* Column sizing — narrative Status gets the room; the rest stay compact */
+  .threats-content td:nth-child(1),
+  .threats-content th:nth-child(1) { white-space: nowrap; width: 6.5rem; color: #6b7280; }   /* When (muted date) */
+  .threats-content td:nth-child(2) { width: 9rem; font-weight: 600; color: #111827; }          /* Entity / Company */
+  .threats-content td:nth-child(3) { width: 9rem; }                                             /* Researcher(s) */
+  .threats-content td:nth-child(4) { width: 13rem; }                                            /* Topic */
+  .threats-content td:nth-child(5) { word-wrap: break-word; overflow-wrap: break-word; min-width: 18rem; }  /* Status */
 
-  /* Links, purple */
-  .threats-content a {
-    color: #673ab6;
-    font-weight: 500;
-  }
-  .threats-content a:hover {
-    color: #322a41;
-    text-decoration: underline;
-  }
+  .threats-content a { color: #673ab6; font-weight: 500; }
+  .threats-content a:hover { color: #322a41; text-decoration: underline; }
 
-  /* Horizontal scroll for tables on mobile */
-  @media (max-width: 1024px) {
+  /* Mobile: let a wide table scroll inside its card */
+  @media (max-width: 900px) {
     .threats-content table {
       display: block;
       overflow-x: auto;


### PR DESCRIPTION
Applies the same treatment as #48 (platforms) to the Research Threats page.

## What
The page rendered its incident tables full-width (`max-w-[1440px]`) with hard dark headers and ad-hoc card CSS — visually disconnected from the site's contained, card-based aesthetic.

## Changes (single file: `layouts/_default/threats.html`)
- Contained to `max-w-6xl`.
- Each incident table uses the site's card tokens (rounded-xl, shade-200 border, shadow-sm).
- Softer chrome: uppercase gray-600 labels on shade-050, shade-100 row borders, hover tint, sticky headers removed.
- Muted `When` date, emphasized Entity/Company column; narrative `Status` keeps wrapping (no truncation).
- Intro prose + notes list set to a comfortable reading measure; mobile tables scroll inside their card.

## Not changed
research-threats data, extraction logic, columns, JSON-LD, submodule pin. Verified against a full production build in Chrome: 4 incident tables (93 rows), console clean, no page overflow.