### PR TITLE
Center framework pillar cards instead of grid-left-aligning

### DIFF
--- a/layouts/framework/list.html
+++ b/layouts/framework/list.html
@@ -62,9 +62,9 @@
       {{ end }}
 
       {{ if and .Pages (not .Params.hide_child_pages) }}
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+      <div class="flex flex-wrap justify-center gap-8">
         {{ range .Pages }}
-        <a href="{{ .Permalink }}" class="card card-hover p-6">
+        <a href="{{ .Permalink }}" class="card card-hover p-6 w-full md:w-[calc(50%-1rem)] lg:w-[calc(33.333%-1.334rem)]">
           <h2 class="text-xl font-semibold text-gray-900 mb-2 group-hover:text-purple">{{ .Title }}</h2>
           {{ with .Description }}
           <p class="text-gray-600 text-sm">{{ . | truncate 140 }}</p>


### PR DESCRIPTION
Follow-up to #52. With the Practices card gone, /framework/ (2 cards) and any pillar list page ending on a partial row (e.g. terms/ with 5 cards → 3+2) left the trailing cards flush-left against an empty grid column instead of centered.

Switches `layouts/framework/list.html` from `grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3` to `flex flex-wrap justify-center` with matching per-card widths, so any card count centers cleanly. Verified locally on /framework/ (2 cards) and /framework/terms/ (5 cards, 3+2 row).