### PR TITLE
fix(ci): stop PR builds cancelling each other and blocking on deploys

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -13,9 +13,13 @@ permissions:
   pages: write
   id-token: write
 
+# Deploys (push to main) serialize on a single "pages" group, because only one
+# deployment to GitHub Pages can be in flight at a time. PR validation builds
+# get their own per-ref group so they neither cancel each other nor contend
+# with a production deploy. Superseded PR builds are cancelled; deploys are not.
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: ${{ github.event_name == 'pull_request' && format('pages-pr-{0}', github.ref) || 'pages' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 defaults:
   run:


### PR DESCRIPTION
## The bug

`hugo.yml` puts **every** run — production deploys *and* pull-request validation builds — into a single global concurrency group:

```yaml
concurrency:
  group: "pages"
  cancel-in-progress: false
```

GitHub permits one *running* and one *pending* run per concurrency group. A third contender **cancels the pending one**.

## What that actually cost us

Dependabot opened 10 PRs on 2026-07-05. They all contended for that single slot and cancelled each other. The result:

- 2 builds succeeded, **8 were cancelled**
- The PRs sat for a week showing **no checks at all**

That last part is the dangerous bit: "cancelled" renders as *"checks not configured"*, not as *"checks failed"*. It reads like the repo has no CI rather than like CI was silently starved — so the natural next move is to merge them, which would be **merging blind into disclose.io**. One of those 10 (#36) bumps Tailwind **3 → 4**, a breaking major: v4 drops the CLI binary that `build:css` invokes via `npx tailwindcss`, so it takes the CSS build out.

## The fix

Split the groups by event:

- **Deploys** (`push` to `main`) keep serializing on `pages` — only one GitHub Pages deployment can be in flight, so that constraint is real.
- **PR builds** get a per-ref group (`pages-pr-<ref>`), so they neither cancel each other nor queue behind a production deploy.
- `cancel-in-progress` is now `true` for PRs only — a superseded PR build *should* be cancelled; a deploy never should.

## After this merges

The 10 open Dependabot PRs will get real CI for the first time. Expect several to go red — **that is the point.** Nothing should be merged into this repo until they do.

---
_Found during a maintenance pass on the disclose.io org, 2026-07-12._