### PR TITLE
Remove 'Open source · vendor-neutral.' from homepage hero

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -4,7 +4,6 @@ description: "The open, vendor-neutral infrastructure that powers vulnerability 
 hero:
   title: "disclose.io"
   subtitle: "The infrastructure that powers vulnerability disclosure and security reporting. Safe, simple, and standardized for everyone."
-  supporting: "Open source · vendor-neutral."
   image: "uploads/tug-of-war.png"
   search: true
   buttons:


### PR DESCRIPTION
Removes the hero supporting line per Casey's request. The hero partial guards it with {{ with .supporting }}, so the element disappears cleanly. Meta descriptions elsewhere are untouched.