### PR TITLE
Redirect programs to directory

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -95,7 +95,7 @@
 
 [[footer_resources]]
   name = "Programs"
-  url = "/programs/"
+  url = "https://directory.disclose.io/"
   weight = 30
 
 [[footer_resources]]
@@ -208,7 +208,7 @@
 
 [[docs]]
   name = "Lookup Programs"
-  url = "/programs/"
+  url = "https://directory.disclose.io/"
   parent = "Resources"
   weight = 10
 

--- a/content/programs.md
+++ b/content/programs.md
@@ -1,6 +1,9 @@
 ---
 title: "VDP Programs"
 description: "Search vulnerability disclosure and bug bounty programs in our database."
-layout: "programs"
+type: "redirect"
+redirect_to: "https://directory.disclose.io/"
+sitemap:
+  disable: true
 tldr: "disclose.io maintains the largest open directory of vulnerability disclosure programs (VDPs) and bug bounty programs on the public internet. Each entry includes the organization, in-scope assets, disclosure policy URL, and any safe-harbor language. The directory is searchable, free to use, and powers downstream tools including lookup.disclose.io."
 ---

--- a/layouts/_default/index.llmsfull.txt
+++ b/layouts/_default/index.llmsfull.txt
@@ -1,6 +1,6 @@
 {{- $limit := 512000 -}}
 {{- $footer := "\n\n---\nOutput truncated at a page boundary because llms-full.txt is capped at 512000 bytes.\n" -}}
-{{- $shellSources := dict "/platforms/" "external/bug-bounty-platforms/README.md" "/threats/" "external/research-threats/README.md" "/programs/" "the Vultron directory widget embedded on /programs/" -}}
+{{- $shellSources := dict "/platforms/" "external/bug-bounty-platforms/README.md" "/threats/" "external/research-threats/README.md" -}}
 {{- $entries := slice -}}
 {{- $homeParts := slice (printf "# %s" .Title) (printf "URL: %s" .Permalink) -}}
 {{- with .Description -}}

--- a/layouts/redirect/single.html
+++ b/layouts/redirect/single.html
@@ -1,0 +1,16 @@
+{{- $target := .Params.redirect_to -}}
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Redirecting to the disclose.io Directory</title>
+    <meta name="robots" content="noindex, follow">
+    <link rel="canonical" href="{{ $target }}">
+    <meta http-equiv="refresh" content="0; url={{ $target }}">
+    <script>window.location.replace({{ $target | jsonify | safeJS }});</script>
+  </head>
+  <body>
+    <p>The VDP Programs directory has moved to <a href="{{ $target }}">directory.disclose.io</a>.</p>
+  </body>
+</html>

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -2,6 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{- range .Data.Pages }}
+  {{- if not .Sitemap.Disable }}
   <url>
     <loc>{{ .Permalink }}</loc>
     {{- with .Sitemap.ChangeFreq }}
@@ -14,6 +15,7 @@
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>
     {{- end }}
   </url>
+  {{- end }}
   {{- end }}
   {{/* AI-readable canonical files, Hugo doesn't add /static/ files to the sitemap automatically,
        and llms-full.txt is generated at build time as a separate output format. Include them

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -7,7 +7,7 @@ We maintain open-source databases, policy templates, tools, and resources to mak
 ## Open Databases
 
 - [Bug Bounty Platforms](https://disclose.io/platforms/): Community-curated directory of every known bug bounty, vulnerability disclosure, and crowdsourced security platform. Open-source at github.com/disclose/bug-bounty-platforms.
-- [VDP Programs](https://disclose.io/programs/): The largest open directory of vulnerability disclosure and bug bounty programs on the public internet. Each entry includes scope, policy URL, and safe-harbor language. Powers lookup.disclose.io.
+- [VDP Programs](https://directory.disclose.io/): The largest open directory of vulnerability disclosure and bug bounty programs on the public internet. Each entry includes scope, policy URL, and safe-harbor language. Powers lookup.disclose.io.
 - [Research Threats](https://disclose.io/threats/): Canonical public archive of legal threats made against security researchers engaged in good-faith vulnerability disclosure. Open-source at github.com/disclose/research-threats.
 - [State of Disclosure / Scoreboard](https://state.disclose.io): The evidence-backed safe-harbor scoreboard for the world's biggest companies (state.disclose.io/top-100).
 


### PR DESCRIPTION
## Summary

- redirect `/programs` to `https://directory.disclose.io/` with crawl-safe fallback markup
- point existing Programs links and `llms.txt` at the canonical directory without changing their visible labels or copy
- remove the legacy URL from generated sitemap and `llms-full.txt` inputs

## Validation

- Hugo 0.128.0 production build passes
- redirect page contains `noindex, follow` and a canonical target
- generated sitemap and HTML contain no stale internal `/programs/` references
- `git diff --check` passes