### PR TITLE
Restore homepage identity copy

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,10 +1,9 @@
 ---
 title: "disclose.io"
-seo_title: "Vulnerability Disclosure Tools & Safe Harbor | disclose.io"
 description: "The open, vendor-neutral infrastructure that powers vulnerability disclosure and security reporting. Safe, simple, and standardized for everyone."
 hero:
-  title: "Open infrastructure for vulnerability disclosure"
-  subtitle: "Practical tools, open data, and standardized safe harbor for security teams and researchers."
+  title: "disclose.io"
+  subtitle: "The infrastructure that powers vulnerability disclosure and security reporting. Safe, simple, and standardized for everyone."
   image: "uploads/tug-of-war.png"
   search: true
   buttons:


### PR DESCRIPTION
## What changed

- remove the homepage-only `seo_title` override
- restore the hero title to `disclose.io`
- restore the original infrastructure subtitle

## Why

Restore the homepage identity copy requested after the SEO/AIO release while leaving the answer block, Directory content, redirects, and analytics instrumentation unchanged.

## Verification

- `bun run build`
- generated `public/index.html` contains `<title>disclose.io</title>`, H1 `disclose.io`, and the restored subtitle
